### PR TITLE
how can I add functions to my typescript ruleset

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
           node-version: 18
       - run: npm ci
       - run: npm test
+      - run: npm run build
       - run: npx semantic-release --branches main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Make your APIs "better" according to APIs You Won't Hate, with this slick comman
 ## Installation
 
 ``` bash
-npm install --save -D @apisyouwonthate/style-guide
+npm install --save -D @philsturgeon/spectral-owasp-ruleset
 npm install --save -D @stoplight/spectral-cli
 ```
 
@@ -17,13 +17,13 @@ Create a local ruleset that extends the style guide. In its most basic form this
 ```
 cd ~/src/<your-api>
 
-echo 'extends: ["@apisyouwonthate/style-guide"]' > .spectral.yaml
+echo 'extends: ["@philsturgeon/spectral-owasp-ruleset"]' > .spectral.yaml
 ```
 
 _If you're using VS Code or Stoplight Studio then the NPM modules will not be available. Instead you can use the CDN hosted version:_
 
 ```
-echo 'extends: ["https://unpkg.com/@apisyouwonthate/style-guide@1.1/ruleset.js"]' > .spectral.yaml
+echo 'extends: ["https://unpkg.com/@philsturgeon/spectral-owasp-ruleset@1.0/dist/ruleset.js"]' > .spectral.yaml
 ```
 
 Next, use Spectral CLI to lint against your OpenAPI description. Don't have any OpenAPI? [Record some HTTP traffic to make OpenAPI](https://apisyouwonthate.com/blog/creating-openapi-from-http-traffic) and then you can switch to API Design-First going forwards.
@@ -45,14 +45,6 @@ You should see some output like this, letting you know there are a few more stan
 
 Now you have some things to work on for your API. Thankfully these are only warnings, which are not going to [fail continuous integration](https://meta.stoplight.io/docs/spectral/ZG9jOjExNTMyOTAx-continuous-integration) (unless [you want them to](https://meta.stoplight.io/docs/spectral/ZG9jOjI1MTg1-spectral-cli#error-results)).
 
-## Backstory
-
-You could write your API Style Guide as a giant manifesto and hope people see it, or you could [automate your API style guide](https://www.apisyouwonthate.com/blog/automated-style-guides-for-rest-graphql-and-grpc) using a tool like Spectral so that your API Style Guide is enforced at the pull request level. This is an integral part of any successful API Governance program, otherwise you're all just wasting time covering the basics far too late in the game.
-
-Spectral runs on top of OpenAPI and AsyncAPI, powering linting in editors, as a CLI tool, in continuous integration, etc., and comes with its [own set of baked 
-in OpenAPI v2/v3 rules](https://meta.stoplight.io/docs/spectral/docs/reference/openapi-rules.md). Making rules about how to write OpenAPI can help beginners write better OpenAPI, but its real power is using rules to make the actual APIs better and more consistent, before there is any programming involved.
-
-This NPM package brings together all sorts of advice found in the books and blog posts from [APIs You Won't Hate](https://apisyouwonthate.com) books. If you apply this to APIs in production, this is basically [Phil Sturgeon](https://philsturgeon.com/) judging your API for free instead of [doing paid consulting](http://phil.tech/consulting). But if you can get this API Style Guide involved in the API Design-First workflow, you're getting free advice on how to design a better API before you waste any time coding, which then means fewer backwards-compatibility breaks as you fix things.
 
 There are [a bunch of other rulesets](https://github.com/stoplightio/spectral-rulesets) you can check out if you feel like making your own API Style Guides, or feel like contributing some new rules here via a pull request.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
       "devDependencies": {
         "@types/jest": "^28.1.6",
         "jest": "^28.0",
-        "ts-jest": "^28.0"
+        "ts-jest": "^28.0",
+        "typescript": "^4.8.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -3982,11 +3983,10 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
       "dev": true,
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -7199,11 +7199,10 @@
       "dev": true
     },
     "typescript": {
-      "version": "4.7.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.7.4.tgz",
-      "integrity": "sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==",
-      "dev": true,
-      "peer": true
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.2.tgz",
+      "integrity": "sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==",
+      "dev": true
     },
     "update-browserslist-db": {
       "version": "1.0.5",

--- a/package.json
+++ b/package.json
@@ -2,11 +2,12 @@
   "name": "@philsturgeon/spectral-owasp-ruleset",
   "version": "0.0.0",
   "description": "Probably don't want to beg hackers to come and take your stuff.",
-  "main": "src/ruleset.ts",
+  "main": "dist/ruleset.ts",
   "directories": {
     "test": "test"
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "jest"
   },
   "repository": {
@@ -33,6 +34,7 @@
   "devDependencies": {
     "@types/jest": "^28.1.6",
     "jest": "^28.0",
-    "ts-jest": "^28.0"
+    "ts-jest": "^28.0",
+    "typescript": "^4.8.2"
   }
 }

--- a/src/functions/checkSecurity.ts
+++ b/src/functions/checkSecurity.ts
@@ -1,0 +1,23 @@
+import { createRulesetFunction, IFunctionResult } from '@stoplight/spectral-core';
+
+export default createRulesetFunction({
+  input: null,
+  options: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      value: true,
+    },
+    required: ['value'],
+  },
+}, (input, options): IFunctionResult[] => {
+  
+  console.log("input", input);
+  console.log("options", options);
+
+  return [
+    {
+      message: `HELLO WORLD FROM CHECK CHECK SECURITY.`,
+    },
+  ];
+});

--- a/src/functions/checkSecurity.ts
+++ b/src/functions/checkSecurity.ts
@@ -6,11 +6,14 @@ export default createRulesetFunction({
     type: 'object',
     additionalProperties: false,
     properties: {
-      value: true,
+      methods: {
+        type: 'array'
+      },
+      nullable: true,
     },
-    required: ['value'],
+    required: [],
   },
-}, (input, options): IFunctionResult[] => {
+}, function checkSecurity (input, options): IFunctionResult[] {
   
   console.log("input", input);
   console.log("options", options);

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -1,4 +1,4 @@
-import { truthy, pattern, schema } from "@stoplight/spectral-functions";
+import { defined, truthy, pattern, schema, falsy } from "@stoplight/spectral-functions";
 import { oas2, oas3 } from "@stoplight/spectral-formats";
 import { DiagnosticSeverity } from "@stoplight/types";
 import checkSecurity from "./functions/checkSecurity";
@@ -358,11 +358,11 @@ export default {
       then: [
         {
           field: "additionalProperties",
-          function: "falsy"
+          function: falsy
         },
         {
           field: "additionalProperties",
-          function: "defined"
+          function: defined
         }
       ]
     },
@@ -382,7 +382,7 @@ export default {
       then: [
         {
           field: "maxProperties",
-          function: "defined"
+          function: defined
         }
       ]
     },

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -1,6 +1,7 @@
-import { pattern, schema } from "@stoplight/spectral-functions";
+import { truthy, pattern, schema } from "@stoplight/spectral-functions";
 import { oas2, oas3 } from "@stoplight/spectral-formats";
 import { DiagnosticSeverity } from "@stoplight/types";
+import checkSecurity from "./functions/checkSecurity";
 
 export default {
   rules: {
@@ -59,17 +60,14 @@ export default {
      * - ❌ Passwords that are weak, plain text, encrypted, poorly hashed, shared, or default passwords
      * - 🤷 Authentication susceptible to brute force attacks and credential stuffing
      * - ✅ Credentials and keys included in URLs
-     * - 🟠 Lack of access token validation (including JWT validation)
-     * 👆 https://github.com/italia/api-oas-checker/blob/master/security/securitySchemes.yml#L3
-     * - 🟠 Unsigned or weakly signed non-expiring JWTs
-     * 👆 https://github.com/italia/api-oas-checker/blob/master/security/securitySchemes.yml#L44
+     * - ✅ Lack of access token validation (including JWT validation)
+     * - ✅ Unsigned or weakly signed non-expiring JWTs
      *
      * How to prevent
      * - ❌ APIs for password reset and one-time links also allow users to authenticate, and should be protected just as rigorously.
      * - ✅ Use standard authentication, token generation, password storage, and multi-factor authentication (MFA).
      * - ❌ Use short-lived access tokens.
-     * - 🟠 Authenticate your apps (so you know who is talking to you).
-     *   👆 https://github.com/italia/api-oas-checker/blob/master/security/security.yml
+     * - ✅ Authenticate your apps (so you know who is talking to you).
      * - ❌ Use stricter rate-limiting for authentication, and implement lockout policies and weak password checks.
      */
 
@@ -96,12 +94,12 @@ export default {
         "API Keys are (usually opaque) strings that\nare passed in headers, cookies or query parameters\nto access APIs.\nThose keys can be eavesdropped, especially when they are stored\nin cookies or passed as URL parameters.\n```\nsecurity:\n- ApiKey: []\npaths:\n  /books: {}\n  /users: {}\nsecuritySchemes:\n  ApiKey:\n    type: apiKey\n    in: cookie\n    name: X-Api-Key\n```",
       message: "ApiKey passed in URL: {{error}}.",
       formats: ["oas3"],
-      severity: "error",
+      severity: DiagnosticSeverity.Error,
       recommended: true,
       given: ['$..[securitySchemes][?(@ && @.type=="apiKey")].in'],
       then: [
         {
-          function: "pattern",
+          function: pattern,
           functionOptions: {
             notMatch: "^(query)$",
           },
@@ -116,13 +114,13 @@ export default {
         "URL parameters MUST NOT contain credentials such as\napikey, password, or secret.\nSee [RAC_GEN_004](https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/04_Raccomandazioni%20di%20implementazione/04_raccomandazioni-tecniche-generali/01_globali.html?highlight=credenziali#rac-gen-004-non-passare-credenziali-o-dati-riservati-nellurl)",
       message: "Credentials are sent via URLs. {{path}} {{error}}",
       formats: ["oas3"],
-      severity: "error",
+      severity: DiagnosticSeverity.Error,
       recommended: true,
       given: ["$..parameters[?(@ && @.in && @.in.match(/query|path/))].name"],
       then: [
         {
           field: "name",
-          function: "pattern",
+          function: pattern,
           functionOptions: {
             notMatch: "/^.*(password|secret|apikey).*$/i",
           },
@@ -137,17 +135,111 @@ export default {
         "The HTTP authorization type in OAS supports\nall the schemes defined in the associated\n[IANA table](https://www.iana.org/assignments/http-authschemes/).\nSome of those schemes are\nnow considered insecure, such as\nnegotiating authentication using specifications\nlike NTLM or OAuth v1.",
       message: "Authentication scheme is insecure: {{error}}",
       formats: ["oas3"],
-      recommended: true,
-      severity: "error",
       given: ['$..[securitySchemes][?(@.type=="http")].scheme'],
       then: [
         {
-          function: "pattern",
+          function: pattern,
           functionOptions: {
             notMatch: "^(negotiate|oauth)$",
           },
         },
       ],
+      severity: DiagnosticSeverity.Error,
+    },
+
+    // Author: Roberto Polli (github.com/ioggstream)
+    // https://github.com/italia/api-oas-checker/blob/master/security/securitySchemes.yml
+    "owasp:api2:2019-jwt-best-practices": {
+      description: "JSON Web Tokens RFC7519 is a compact, URL-safe means of representing\nclaims to be transferred between two parties. JWT can be enclosed in\nencrypted or signed tokens like JWS and JWE.\nThe [JOSE IANA registry](https://www.iana.org/assignments/jose/jose.xhtml)\nprovides algorithms information.\nRFC8725 describes common pitfalls in the JWx specifications and in\ntheir implementations, such as:\n- the ability to ignore algorithms, eg. `{\"alg\": \"none\"}`;\n- using insecure algorithms like `RSASSA-PKCS1-v1_5` eg. `{\"alg\": \"RS256\"}`.\nAn API using JWT should explicit in the `description`\nthat the implementation conforms to RFC8725.\n```\ncomponents:\n  securitySchemes:\n    JWTBearer:\n      type: http\n      scheme: bearer\n      bearerFormat: JWT\n      description: |-\n        A bearer token in the format of a JWS and conformato\n        to the specifications included in RFC8725.\n```",
+      message: "JWT usage should be detailed in `description` {{error}}.",
+      given: [
+        "$..[securitySchemes][?(@.type==\"oauth2\")]",
+        "$..[securitySchemes][?(@.bearerFormat==\"jwt\" || @.bearerFormat==\"JWT\")]"
+      ],
+      "then": [
+        {
+          field: "description",
+          function: truthy
+        },
+        {
+          field: "description",
+          function: pattern,
+          functionOptions: {
+            match: ".*RFC8725.*"
+          }
+        }
+      ]
+    },
+
+    // Author: Roberto Polli (github.com/ioggstream)
+    // https://github.com/italia/api-oas-checker/blob/master/security/security.yml
+    "owasp:api2:2019-protection-global-unsafe": {
+      description: "Your API should be protected by a `security` rule either at\nglobal or operation level.\nAll operations should be protected especially when they\nnot safe (methods that do not alter the state of the server) \nHTTP methods like `POST`, `PUT`, `PATCH` and `DELETE`.\nThis is done with one or more non-empty `security` rules.\n\nSecurity rules are defined in the `securityScheme` section.\n\nAn example of a security rule applied at global level.\n\n```\nsecurity:\n- BasicAuth: []\npaths:\n  /books: {}\n  /users: {}\nsecuritySchemes:\n  BasicAuth:\n    scheme: http\n    type: basic\n```\n\nAn example of a security rule applied at operation level, which\neventually overrides the global one\n\n```\npaths:\n  /books:\n    post:\n      security:\n      - AccessToken: []\nsecuritySchemes:\n  BasicAuth:\n    scheme: http\n    type: basic\n  AccessToken:\n    scheme: http\n    type: bearer\n    bearerFormat: JWT\n```",
+      message: "The following unsafe operation is not protected by a `security` rule: {{path}}",
+      severity: "error",
+      given: "$",
+      then: [
+        {
+          "function": checkSecurity,
+          "functionOptions": {
+            "schemesPath": [
+              "securitySchemes"
+            ],
+            "nullable": true,
+            "methods": [
+              "post",
+              "patch",
+              "delete",
+              "put"
+            ]
+          }
+        }
+      ]
+    },
+    
+    "owasp:api2:2019-protection-global-unsafe-strict": {
+      description: "Check if the operation is protected at operation level.\nOtherwise, the global `#/security` property is check.\n\nYour API should be protected by a `security` rule either at\nglobal or operation level.\nAll operations should be protected especially when they\nnot safe (methods that do not alter the state of the server) \nHTTP methods like `POST`, `PUT`, `PATCH` and `DELETE`.\nThis is done with one or more non-empty `security` rules.\n\nSecurity rules are defined in the `securityScheme` section.\n\nAn example of a security rule applied at global level.\n\n```\nsecurity:\n- BasicAuth: []\npaths:\n  /books: {}\n  /users: {}\nsecuritySchemes:\n  BasicAuth:\n    scheme: http\n    type: basic\n```\n\nAn example of a security rule applied at operation level, which\neventually overrides the global one\n\n```\npaths:\n  /books:\n    post:\n      security:\n      - AccessToken: []\nsecuritySchemes:\n  BasicAuth:\n    scheme: http\n    type: basic\n  AccessToken:\n    scheme: http\n    type: bearer\n    bearerFormat: JWT\n```",
+      message: "The following unsafe operation is not protected by a `security` rule: {{path}}",
+      severity: "info",
+      given: "$",
+      then: [
+        {
+          "function": checkSecurity,
+          "functionOptions": {
+            "schemesPath": [
+              "securitySchemes"
+            ],
+            "nullable": false,
+            "methods": [
+              "post",
+              "patch",
+              "delete",
+              "put"
+            ]
+          }
+        }
+      ]
+    },
+    "sec-protection-global-safe": {
+      description: "Check if the operation is protected at operation level.\nOtherwise, the global `#/security` property is check.\n\nYour API should be protected by a `security` rule either at\nglobal or operation level.\nAll operations should be protected especially when they\nnot safe (methods that do not alter the state of the server) \nHTTP methods like `POST`, `PUT`, `PATCH` and `DELETE`.\nThis is done with one or more non-empty `security` rules.\n\nSecurity rules are defined in the `securityScheme` section.\n\nAn example of a security rule applied at global level.\n\n```\nsecurity:\n- BasicAuth: []\npaths:\n  /books: {}\n  /users: {}\nsecuritySchemes:\n  BasicAuth:\n    scheme: http\n    type: basic\n```\n\nAn example of a security rule applied at operation level, which\neventually overrides the global one\n\n```\npaths:\n  /books:\n    post:\n      security:\n      - AccessToken: []\nsecuritySchemes:\n  BasicAuth:\n    scheme: http\n    type: basic\n  AccessToken:\n    scheme: http\n    type: bearer\n    bearerFormat: JWT\n```",
+      message: "The following operation is not protected by a `security` rule: {{path}}",
+      severity: "info",
+      given: "$",
+      then: [
+        {
+          function: checkSecurity,
+          functionOptions: {
+            schemesPath: [
+              "securitySchemes"
+            ],
+            nullable: true,
+            methods: [
+              "get",
+              "head"
+            ]
+          }
+        }
+      ]
     },
 
     /**
@@ -176,7 +268,7 @@ export default {
       then: [
         {
           field: "400",
-          function: "truthy",
+          function: truthy,
         },
       ],
     },
@@ -190,7 +282,7 @@ export default {
       then: [
         {
           field: "429",
-          function: "truthy",
+          function: truthy,
         },
       ],
     },
@@ -204,7 +296,7 @@ export default {
       then: [
         {
           field: "500",
-          function: "truthy",
+          function: truthy,
         },
       ],
     },
@@ -254,14 +346,55 @@ export default {
      *
      * How to prevent
      * - ❌ Do not automatically bind incoming data and internal objects.
-     * - 🟠 Explicitly define all the parameters and payloads you are expecting.
-     * 👆 https://github.com/italia/api-oas-checker/blob/master/security/objects.yml#L2
+     * - ✅ Explicitly define all the parameters and payloads you are expecting.
      * - 🟠 Use the readOnly property set to true in object schemas for all properties that can be retrieved through APIs but should never be modified.
      * - 🟠 Precisely define the schemas, types, and patterns you will accept in requests at design time and enforce them at runtime.
      */
 
-    // 'owasp:api6:2019-mass-assignment':
-    // 'https://apisecurity.io/encyclopedia/content/owasp/api6-mass-assignment',
+    
+    // Author: Roberto Polli (github.com/ioggstream)
+    // https://github.com/italia/api-oas-checker/blob/master/security/objects.yml
+    "owasp:api6:2019-no-additionalProperties": {
+      description: "By default JSON Schema allows additional properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation.",
+      message: "Objects should not allow unconstrained additionalProperties. Disable them with `additionalProperties: false` or add `maxProperties`.",
+      formats: [
+        "oas3"
+      ],
+      severity: DiagnosticSeverity.Warning,
+      given: [
+        "$..[?(@.type==\"object\" && @.additionalProperties)]"
+      ],
+      then: [
+        {
+          field: "additionalProperties",
+          function: "falsy"
+        },
+        {
+          field: "additionalProperties",
+          function: "defined"
+        }
+      ]
+    },
+
+    // Author: Roberto Polli (github.com/ioggstream)
+    // https://github.com/italia/api-oas-checker/blob/master/security/objects.yml
+    "owasp:api6:2019-constrained-additionalProperties": {
+      description: "By default JSON Schema allows additional properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation.",
+      message: "Objects should not allow unconstrained additionalProperties. Disable them with `additionalProperties: false` or add `maxProperties`.",
+      formats: [
+        "oas3"
+      ],
+      severity: DiagnosticSeverity.Warning,
+      given: [
+        "$..[?(@.type==\"object\" && @.additionalProperties &&  @.additionalProperties!=true &&  @.additionalProperties!=false )]"
+      ],
+      then: [
+        {
+          field: "maxProperties",
+          function: "defined"
+        }
+      ]
+    },
 
     /**
      * API7:2019 — Security misconfiguration

--- a/src/ruleset.ts
+++ b/src/ruleset.ts
@@ -93,7 +93,7 @@ export default {
       description:
         "API Keys are (usually opaque) strings that\nare passed in headers, cookies or query parameters\nto access APIs.\nThose keys can be eavesdropped, especially when they are stored\nin cookies or passed as URL parameters.\n```\nsecurity:\n- ApiKey: []\npaths:\n  /books: {}\n  /users: {}\nsecuritySchemes:\n  ApiKey:\n    type: apiKey\n    in: cookie\n    name: X-Api-Key\n```",
       message: "ApiKey passed in URL: {{error}}.",
-      formats: ["oas3"],
+      formats: [oas3],
       severity: DiagnosticSeverity.Error,
       recommended: true,
       given: ['$..[securitySchemes][?(@ && @.type=="apiKey")].in'],
@@ -113,7 +113,7 @@ export default {
       description:
         "URL parameters MUST NOT contain credentials such as\napikey, password, or secret.\nSee [RAC_GEN_004](https://docs.italia.it/italia/piano-triennale-ict/lg-modellointeroperabilita-docs/it/bozza/doc/04_Raccomandazioni%20di%20implementazione/04_raccomandazioni-tecniche-generali/01_globali.html?highlight=credenziali#rac-gen-004-non-passare-credenziali-o-dati-riservati-nellurl)",
       message: "Credentials are sent via URLs. {{path}} {{error}}",
-      formats: ["oas3"],
+      formats: [oas3],
       severity: DiagnosticSeverity.Error,
       recommended: true,
       given: ["$..parameters[?(@ && @.in && @.in.match(/query|path/))].name"],
@@ -134,7 +134,7 @@ export default {
       description:
         "The HTTP authorization type in OAS supports\nall the schemes defined in the associated\n[IANA table](https://www.iana.org/assignments/http-authschemes/).\nSome of those schemes are\nnow considered insecure, such as\nnegotiating authentication using specifications\nlike NTLM or OAuth v1.",
       message: "Authentication scheme is insecure: {{error}}",
-      formats: ["oas3"],
+      formats: [oas3],
       given: ['$..[securitySchemes][?(@.type=="http")].scheme'],
       then: [
         {
@@ -182,9 +182,6 @@ export default {
         {
           "function": checkSecurity,
           "functionOptions": {
-            "schemesPath": [
-              "securitySchemes"
-            ],
             "nullable": true,
             "methods": [
               "post",
@@ -206,9 +203,6 @@ export default {
         {
           "function": checkSecurity,
           "functionOptions": {
-            "schemesPath": [
-              "securitySchemes"
-            ],
             "nullable": false,
             "methods": [
               "post",
@@ -220,7 +214,7 @@ export default {
         }
       ]
     },
-    "sec-protection-global-safe": {
+    "owasp:api2:2019-protection-global-safe": {
       description: "Check if the operation is protected at operation level.\nOtherwise, the global `#/security` property is check.\n\nYour API should be protected by a `security` rule either at\nglobal or operation level.\nAll operations should be protected especially when they\nnot safe (methods that do not alter the state of the server) \nHTTP methods like `POST`, `PUT`, `PATCH` and `DELETE`.\nThis is done with one or more non-empty `security` rules.\n\nSecurity rules are defined in the `securityScheme` section.\n\nAn example of a security rule applied at global level.\n\n```\nsecurity:\n- BasicAuth: []\npaths:\n  /books: {}\n  /users: {}\nsecuritySchemes:\n  BasicAuth:\n    scheme: http\n    type: basic\n```\n\nAn example of a security rule applied at operation level, which\neventually overrides the global one\n\n```\npaths:\n  /books:\n    post:\n      security:\n      - AccessToken: []\nsecuritySchemes:\n  BasicAuth:\n    scheme: http\n    type: basic\n  AccessToken:\n    scheme: http\n    type: bearer\n    bearerFormat: JWT\n```",
       message: "The following operation is not protected by a `security` rule: {{path}}",
       severity: "info",
@@ -229,9 +223,6 @@ export default {
         {
           function: checkSecurity,
           functionOptions: {
-            schemesPath: [
-              "securitySchemes"
-            ],
             nullable: true,
             methods: [
               "get",
@@ -263,7 +254,7 @@ export default {
     "owasp:api3:2019-define-error-responses-400": {
       description: "400 response should be defined.",
       message: "{{description}}. Missing {{property}}",
-      severity: "warning",
+      severity: DiagnosticSeverity.Warning,
       given: "$.paths..responses",
       then: [
         {
@@ -277,7 +268,7 @@ export default {
     "owasp:api3:2019-define-error-responses-429": {
       description: "429 response should be defined.",
       message: "{{description}}. Missing {{property}}",
-      severity: "warning",
+      severity: DiagnosticSeverity.Warning,
       given: "$.paths..responses",
       then: [
         {
@@ -291,7 +282,7 @@ export default {
     "owasp:api3:2019-define-error-responses-500": {
       description: "500 response should be defined.",
       message: "{{description}}. Missing {{property}}",
-      severity: "warning",
+      severity: DiagnosticSeverity.Warning,
       given: "$.paths..responses",
       then: [
         {
@@ -358,7 +349,7 @@ export default {
       description: "By default JSON Schema allows additional properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation.",
       message: "Objects should not allow unconstrained additionalProperties. Disable them with `additionalProperties: false` or add `maxProperties`.",
       formats: [
-        "oas3"
+        oas3
       ],
       severity: DiagnosticSeverity.Warning,
       given: [
@@ -382,7 +373,7 @@ export default {
       description: "By default JSON Schema allows additional properties, which can potentially lead to mass assignment issues, where unspecified fields are passed to the API without validation.",
       message: "Objects should not allow unconstrained additionalProperties. Disable them with `additionalProperties: false` or add `maxProperties`.",
       formats: [
-        "oas3"
+        oas3
       ],
       severity: DiagnosticSeverity.Warning,
       given: [

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
Trying to add check security, which will make sure there is either global security applied or operation level security, for every operation. Sadly I cannot work out how to get it going with this slick TypeScript format, as the docs don't cover that and my guesswork is leading me to: 

```
spectral lint ../protect-earth-api/api/openapi.yaml --ruleset=src/ruleset.ts --verbose
Error running Spectral!
Error #1: Could not resolve './functions/checkSecurity' from src/ruleset.ts
          at error            …hared/rollup.js:198  base = Object.assig…
          at handleResolveId  …red/rollup.js:22508  return error(errUnr…
          at                  …red/rollup.js:22471  this.handleResolveI…
```

Any tips welcome.